### PR TITLE
Remove react from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "invariant": "^2.0.0"
   },
   "peerDependencies": {
-    "redux": "^1.0.0 || 1.0.0-alpha || 1.0.0-rc",
-    "react": "^0.13.0 || 0.14.0-beta1"
+    "redux": "^1.0.0 || 1.0.0-alpha || 1.0.0-rc"
   }
 }


### PR DESCRIPTION
Installing react-redux with React Native ends up installing web React because npm automatically installs peer dependencies (until npm 3.0 is here). Likewise it'd be noisy if react-native were listed under the peer dependencies when most people don't need it. One day this won't be an issue anymore React splits into three pieces -- react, react-dom, react-native w/react as an external dependency.

(I understand if you don't want to take this PR especially when React 0.14 is out and parent v owner context becomes an issue...)