### PR TITLE
Start API change for connect decorator

### DIFF
--- a/src/components/createConnectDecorator.js
+++ b/src/components/createConnectDecorator.js
@@ -4,7 +4,7 @@ import shallowEqualScalar from '../utils/shallowEqualScalar';
 export default function createConnectDecorator(React, Connector) {
   const { Component } = React;
 
-  return function connect(select) {
+  return function connect(slicer, actionCreators) {
     return DecoratedComponent => class ConnectorDecorator extends Component {
       static displayName = `Connector(${getDisplayName(DecoratedComponent)})`;
       static DecoratedComponent = DecoratedComponent;
@@ -14,8 +14,17 @@ export default function createConnectDecorator(React, Connector) {
       }
 
       render() {
+        // Linter doesn't allow const slicerFn = slicer || () => ({});
+        let slicerFn = slicer;
+        if (slicerFn === null) {
+          slicerFn = () => ({});
+        }
+
         return (
-          <Connector select={state => select(state, this.props)}>
+          <Connector
+            slicer={state => slicerFn(state, this.props)}
+            actionCreators={actionCreators}
+          >
             {stuff => <DecoratedComponent {...stuff} {...this.props} />}
           </Connector>
         );

--- a/test/components/Connector.spec.js
+++ b/test/components/Connector.spec.js
@@ -49,13 +49,13 @@ describe('React', () => {
     });
 
     it('should subscribe to the store changes', () => {
-      const reducer = combineReducers({string: stringBuilder})
+      const reducer = combineReducers({string: stringBuilder});
       const store = createStore(reducer);
 
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={state => ({ string: state.string })}>
+            <Connector slicer={state => ({ string: state.string })}>
               {({ string }) => <div string={string} />}
             </Connector>
           )}
@@ -71,7 +71,7 @@ describe('React', () => {
     });
 
     it('should unsubscribe before unmounting', () => {
-      const reducer = combineReducers({string: stringBuilder})
+      const reducer = combineReducers({string: stringBuilder});
       const store = createStore(reducer);
       const subscribe = store.subscribe;
 
@@ -88,7 +88,7 @@ describe('React', () => {
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={state => ({ string: state.string })}>
+            <Connector slicer={state => ({ string: state.string })}>
               {({ string }) => <div string={string} />}
             </Connector>
           )}
@@ -102,7 +102,7 @@ describe('React', () => {
     });
 
     it('should shallowly compare the selected state to prevent unnecessary updates', () => {
-      const reducer = combineReducers({string: stringBuilder})
+      const reducer = combineReducers({string: stringBuilder});
       const store = createStore(reducer);
       const spy = expect.createSpy(() => {});
       function render({ string }) {
@@ -113,7 +113,7 @@ describe('React', () => {
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={state => ({ string: state.string })}>
+            <Connector slicer={state => ({ string: state.string })}>
               {render}
             </Connector>
           )}
@@ -152,14 +152,14 @@ describe('React', () => {
       class Container extends Component {
         constructor() {
           super();
-          this.state = { select: selectA };
+          this.state = { slicer: selectA };
         }
 
         render() {
           return (
             <Provider store={store}>
               {() =>
-                <Connector select={this.state.select}>
+                <Connector slicer={this.state.slicer}>
                   {render}
                 </Connector>
               }
@@ -172,7 +172,7 @@ describe('React', () => {
       let div = TestUtils.findRenderedDOMComponentWithTag(tree, 'div');
       expect(div.props.children).toBe(42);
 
-      tree.setState({ select: selectB });
+      tree.setState({ slicer: selectB });
       expect(div.props.children).toBe(72);
     });
 
@@ -200,25 +200,25 @@ describe('React', () => {
         TestUtils.renderIntoDocument(
           <Provider store={store}>
             {() => (
-              <Connector select={() => 1}>
+              <Connector slicer={() => 1}>
                 {() => <div />}
               </Connector>
             )}
           </Provider>
         );
-      }).toThrow(/select/);
+      }).toThrow(/slicer/);
 
       expect(() => {
         TestUtils.renderIntoDocument(
           <Provider store={store}>
             {() => (
-              <Connector select={() => 'hey'}>
+              <Connector slicer={() => 'hey'}>
                 {() => <div />}
               </Connector>
             )}
           </Provider>
         );
-      }).toThrow(/select/);
+      }).toThrow(/slicer/);
 
       function AwesomeMap() { }
 
@@ -226,18 +226,18 @@ describe('React', () => {
         TestUtils.renderIntoDocument(
           <Provider store={store}>
             {() => (
-              <Connector select={() => new AwesomeMap()}>
+              <Connector slicer={() => new AwesomeMap()}>
                 {() => <div />}
               </Connector>
             )}
           </Provider>
         );
-      }).toThrow(/select/);
+      }).toThrow(/slicer/);
     });
 
     it('should not setState when renderToString is called on the server', () => {
       const { renderToString } = React;
-      const reducer = combineReducers({string: stringBuilder})
+      const reducer = combineReducers({string: stringBuilder});
       const store = createStore(reducer);
 
       class TestComp extends Component {
@@ -256,7 +256,7 @@ describe('React', () => {
       const el = (
         <Provider store={store}>
           {() => (
-            <Connector select={state => ({ string: state.string })}>
+            <Connector slicer={state => ({ string: state.string })}>
               {({ string }) => <TestComp string={string} />}
             </Connector>
           )}
@@ -267,7 +267,7 @@ describe('React', () => {
     });
 
     it('should handle dispatch inside componentDidMount', () => {
-      const reducer = combineReducers({string: stringBuilder})
+      const reducer = combineReducers({string: stringBuilder});
       const store = createStore(reducer);
 
       class TestComp extends Component {
@@ -286,7 +286,7 @@ describe('React', () => {
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={state => ({ string: state.string })}>
+            <Connector slicer={state => ({ string: state.string })}>
               {({ string }) => <TestComp string={string} />}
             </Connector>
           )}

--- a/test/components/Connector.spec.js
+++ b/test/components/Connector.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import jsdomReact from './jsdomReact';
 import React, { PropTypes, Component } from 'react/addons';
-import { createStore } from 'redux';
+import { createStore, combineReducers } from 'redux';
 import { Connector } from '../../src/index';
 
 const { TestUtils } = React.addons;
@@ -32,7 +32,7 @@ describe('React', () => {
     }
 
     it('should receive the store in the context', () => {
-      const store = createStore({});
+      const store = createStore(combineReducers({}));
 
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
@@ -49,12 +49,13 @@ describe('React', () => {
     });
 
     it('should subscribe to the store changes', () => {
-      const store = createStore(stringBuilder);
+      const reducer = combineReducers({string: stringBuilder})
+      const store = createStore(reducer);
 
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={string => ({ string })}>
+            <Connector select={state => ({ string: state.string })}>
               {({ string }) => <div string={string} />}
             </Connector>
           )}
@@ -70,7 +71,8 @@ describe('React', () => {
     });
 
     it('should unsubscribe before unmounting', () => {
-      const store = createStore(stringBuilder);
+      const reducer = combineReducers({string: stringBuilder})
+      const store = createStore(reducer);
       const subscribe = store.subscribe;
 
       // Keep track of unsubscribe by wrapping subscribe()
@@ -86,7 +88,7 @@ describe('React', () => {
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={string => ({ string })}>
+            <Connector select={state => ({ string: state.string })}>
               {({ string }) => <div string={string} />}
             </Connector>
           )}
@@ -100,7 +102,8 @@ describe('React', () => {
     });
 
     it('should shallowly compare the selected state to prevent unnecessary updates', () => {
-      const store = createStore(stringBuilder);
+      const reducer = combineReducers({string: stringBuilder})
+      const store = createStore(reducer);
       const spy = expect.createSpy(() => {});
       function render({ string }) {
         spy();
@@ -110,7 +113,7 @@ describe('React', () => {
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={string => ({ string })}>
+            <Connector select={state => ({ string: state.string })}>
               {render}
             </Connector>
           )}
@@ -129,10 +132,10 @@ describe('React', () => {
     });
 
     it('should recompute the state slice when the select prop changes', () => {
-      const store = createStore({
+      const store = createStore(combineReducers({
         a: () => 42,
         b: () => 72
-      });
+      }));
 
       function selectA(state) {
         return { result: state.a };
@@ -174,7 +177,7 @@ describe('React', () => {
     });
 
     it('should pass dispatch() to the child function', () => {
-      const store = createStore({});
+      const store = createStore(combineReducers({}));
 
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
@@ -191,7 +194,7 @@ describe('React', () => {
     });
 
     it('should throw an error if select returns anything but a plain object', () => {
-      const store = createStore({});
+      const store = createStore(combineReducers({}));
 
       expect(() => {
         TestUtils.renderIntoDocument(
@@ -234,7 +237,8 @@ describe('React', () => {
 
     it('should not setState when renderToString is called on the server', () => {
       const { renderToString } = React;
-      const store = createStore(stringBuilder);
+      const reducer = combineReducers({string: stringBuilder})
+      const store = createStore(reducer);
 
       class TestComp extends Component {
         componentWillMount() {
@@ -252,7 +256,7 @@ describe('React', () => {
       const el = (
         <Provider store={store}>
           {() => (
-            <Connector select={string => ({ string })}>
+            <Connector select={state => ({ string: state.string })}>
               {({ string }) => <TestComp string={string} />}
             </Connector>
           )}
@@ -263,7 +267,8 @@ describe('React', () => {
     });
 
     it('should handle dispatch inside componentDidMount', () => {
-      const store = createStore(stringBuilder);
+      const reducer = combineReducers({string: stringBuilder})
+      const store = createStore(reducer);
 
       class TestComp extends Component {
         componentDidMount() {
@@ -281,7 +286,7 @@ describe('React', () => {
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>
           {() => (
-            <Connector select={string => ({ string })}>
+            <Connector select={state => ({ string: state.string })}>
               {({ string }) => <TestComp string={string} />}
             </Connector>
           )}

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import jsdomReact from './jsdomReact';
 import React, { PropTypes, Component } from 'react/addons';
-import { createStore } from 'redux';
+import { createStore, combineReducers } from 'redux';
 import { Provider } from '../../src/index';
 
 const { TestUtils } = React.addons;
@@ -21,7 +21,7 @@ describe('React', () => {
     }
 
     it('should add the store to the child context', () => {
-      const store = createStore({});
+      const store = createStore(combineReducers({}));
 
       const tree = TestUtils.renderIntoDocument(
         <Provider store={store}>

--- a/test/components/provide.spec.js
+++ b/test/components/provide.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import jsdomReact from './jsdomReact';
 import React, { PropTypes, Component } from 'react/addons';
-import { createStore } from 'redux';
+import { createStore, combineReducers } from 'redux';
 import { provide, Provider } from '../../src/index';
 
 const { TestUtils } = React.addons;
@@ -21,7 +21,7 @@ describe('React', () => {
     }
 
     it('should wrap the component into Provider', () => {
-      const store = createStore({});
+      const store = createStore(combineReducers({}));
 
       @provide(store)
       class Container extends Component {
@@ -42,7 +42,7 @@ describe('React', () => {
     });
 
     it('sets the displayName correctly', () => {
-      @provide(createStore({}))
+      @provide(createStore(combineReducers({})))
       class Container extends Component {
         render() {
           return <div />;


### PR DESCRIPTION
Start of some work on #1 

Rename select to slicer to be clearer (and goes well with the existing variable this.state.slice which is the result of calling slicer

Add binding for action creator, a tad different from what was suggested in the thread:
```js
@connect(
     state => ({string: state.foo}),
     dispatch =>({
        append: (...args) => dispatch(appender(...args))
     })
 )
```

```js
@connect(
   state => ({string: state.foo}),
   {append: appender} // equivalent to MyActionCreators in a real app (import *)
)
```

I haven't done merge yet as there are still things unclear imo (what happens if you get several part of the state etc) and I wasn't sure whether I missed something from the discussion so I'll add merge if everything is ok and clear