### PR TITLE
Readme: connect() should wrap Counter in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ function mapDispatchToProps(dispatch) {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(CounterContainer);
+)(Counter);
 
 // You can also pass an object instead of defining `mapDispatchToProps`:
-// export default connect(mapStateToProps, CounterActionCreators)(CounterContainer);
+// export default connect(mapStateToProps, CounterActionCreators)(Counter);
 
 // Or you can pass `dispatch` down as a prop if you omit `mapDispatchToProps`:
-// export default connect(mapStateToProps)(CounterContainer);
+// export default connect(mapStateToProps)(Counter);
 
 // See more recipes in detailed connect() examples below.
 ```


### PR DESCRIPTION
New to the project, so it's possible I'm reading this wrong, but I think in this example `connect()` is wrapping the wrong component.