### PR TITLE
Hardcode decorated component ref

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -81,7 +81,6 @@ export default function createConnect(React) {
       constructor(props, context) {
         super(props, context);
         this.version = version;
-        this.setUnderlyingRef = ::this.setUnderlyingRef;
 
         this.stateProps = computeStateProps(context);
         this.dispatchProps = computeDispatchProps(context);
@@ -179,16 +178,12 @@ export default function createConnect(React) {
       }
 
       getUnderlyingRef() {
-        return this.underlyingRef;
-      }
-
-      setUnderlyingRef(instance) {
-        this.underlyingRef = instance;
+        return this.refs.underlyingRef;
       }
 
       render() {
         return (
-          <DecoratedComponent ref={this.setUnderlyingRef}
+          <DecoratedComponent ref='underlyingRef'
                               {...this.state} />
         );
       }


### PR DESCRIPTION
Not setting the ref of the inner component makes it a pain to [test through refs](https://github.com/QubitProducts/react-test-tree#higher-order-components).

Is there any specific reason for setting the ref through `setUnderlyingRef` or could we just set the ref to a string?