### PR TITLE
Support passing store in via props for testing

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -93,7 +93,7 @@ export default function createConnect(React) {
             `props of "${this.constructor.displayName}". ` +
             `Either wrap the root component in a <Provider>, ` +
             `or explicitly pass "store" as a prop to "${this.constructor.displayName}".`
-          )
+          );
 
           this.stateProps = computeStateProps(this.store);
           this.dispatchProps = computeDispatchProps(this.store);

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -34,8 +34,8 @@ export default function createConnect(React) {
     // Helps track hot reloading.
     const version = nextVersion++;
 
-    function computeStateProps(context) {
-      const state = context.store.getState();
+    function computeStateProps(store) {
+      const state = store.getState();
       const stateProps = finalMapStateToProps(state);
       invariant(
         isPlainObject(stateProps),
@@ -45,8 +45,8 @@ export default function createConnect(React) {
       return stateProps;
     }
 
-    function computeDispatchProps(context) {
-      const { dispatch } = context.store;
+    function computeDispatchProps(store) {
+      const { dispatch } = store;
       const dispatchProps = finalMapDispatchToProps(dispatch);
       invariant(
         isPlainObject(dispatchProps),
@@ -72,7 +72,7 @@ export default function createConnect(React) {
         static WrappedComponent = WrappedComponent;
 
         static contextTypes = {
-          store: storeShape.isRequired
+          store: storeShape
         };
 
         shouldComponentUpdate(nextProps, nextState) {
@@ -82,13 +82,17 @@ export default function createConnect(React) {
         constructor(props, context) {
           super(props, context);
           this.version = version;
-          this.stateProps = computeStateProps(context);
-          this.dispatchProps = computeDispatchProps(context);
+          this.store = props.store || context.store;
+
+          invariant(this.store, '`store` must be passed in via the context or props');
+
+          this.stateProps = computeStateProps(this.store);
+          this.dispatchProps = computeDispatchProps(this.store);
           this.state = this.computeNextState();
         }
 
         recomputeStateProps() {
-          const nextStateProps = computeStateProps(this.context);
+          const nextStateProps = computeStateProps(this.store);
           if (shallowEqual(nextStateProps, this.stateProps)) {
             return false;
           }
@@ -98,7 +102,7 @@ export default function createConnect(React) {
         }
 
         recomputeDispatchProps() {
-          const nextDispatchProps = computeDispatchProps(this.context);
+          const nextDispatchProps = computeDispatchProps(this.store);
           if (shallowEqual(nextDispatchProps, this.dispatchProps)) {
             return false;
           }
@@ -128,7 +132,7 @@ export default function createConnect(React) {
 
         trySubscribe() {
           if (shouldSubscribe && !this.unsubscribe) {
-            this.unsubscribe = this.context.store.subscribe(::this.handleChange);
+            this.unsubscribe = this.store.subscribe(::this.handleChange);
             this.handleChange();
           }
         }

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -75,6 +75,10 @@ export default function createConnect(React) {
           store: storeShape
         };
 
+        static propTypes = {
+          store: storeShape
+        };
+
         shouldComponentUpdate(nextProps, nextState) {
           return !shallowEqual(this.state, nextState);
         }

--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -88,7 +88,12 @@ export default function createConnect(React) {
           this.version = version;
           this.store = props.store || context.store;
 
-          invariant(this.store, '`store` must be passed in via the context or props');
+          invariant(this.store,
+            `Could not find "store" in either the context or ` +
+            `props of "${this.constructor.displayName}". ` +
+            `Either wrap the root component in a <Provider>, ` +
+            `or explicitly pass "store" as a prop to "${this.constructor.displayName}".`
+          )
 
           this.stateProps = computeStateProps(this.store);
           this.dispatchProps = computeDispatchProps(this.store);

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -739,6 +739,26 @@ describe('React', () => {
       expect(actualState).toEqual(expectedState);
     });
 
+    it('should throw an error if the store is not in the props or context', () => {
+      class Container extends Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      const decorator = connect(state => {});
+      const Decorated = decorator(Container);
+      const expectedError =
+        `Invariant Violation: Could not find "store" in either the context ` +
+        `or props of "Connect(Container)". Either wrap the root component in a `+
+        `<Provider>, or explicitly pass "store" as a prop to "Connect(Container)".`;
+
+      expect(() => TestUtils.renderIntoDocument(<Decorated />)).toThrow(e => {
+        expect(e.message).toEqual(expectedError)
+        return true
+      })
+    })
+
     it('should return the instance of the wrapped component for use in calling child methods', () => {
       const store = createStore(() => ({}));
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -713,6 +713,32 @@ describe('React', () => {
       expect(decorated.WrappedComponent).toBe(Container);
     });
 
+    it('should use the store from the props instead of from the context if present', () => {
+      class Container extends Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      let actualState;
+
+      const expectedState = { foos: {} };
+      const decorator = connect(state => {
+        actualState = state;
+        return {};
+      });
+      const Decorated = decorator(Container);
+      const mockStore = {
+        dispatch: () => {},
+        subscribe: () => {},
+        getState: () => expectedState
+      };
+
+      TestUtils.renderIntoDocument(<Decorated store={mockStore} />);
+
+      expect(actualState).toEqual(expectedState);
+    });
+
     it('should return the instance of the wrapped component for use in calling child methods', () => {
       const store = createStore(() => ({}));
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -746,18 +746,18 @@ describe('React', () => {
         }
       }
 
-      const decorator = connect(state => {});
+      const decorator = connect(() => {});
       const Decorated = decorator(Container);
       const expectedError =
         `Invariant Violation: Could not find "store" in either the context ` +
-        `or props of "Connect(Container)". Either wrap the root component in a `+
+        `or props of "Connect(Container)". Either wrap the root component in a ` +
         `<Provider>, or explicitly pass "store" as a prop to "Connect(Container)".`;
 
       expect(() => TestUtils.renderIntoDocument(<Decorated />)).toThrow(e => {
-        expect(e.message).toEqual(expectedError)
-        return true
-      })
-    })
+        expect(e.message).toEqual(expectedError);
+        return true;
+      });
+    });
 
     it('should return the instance of the wrapped component for use in calling child methods', () => {
       const store = createStore(() => ({}));


### PR DESCRIPTION
Allow you to pass the redux store in via props to make it easier to unit test (Instead of having to mess with `Provider`'s or contexts)

See also #38

Closes #33