### PR TITLE
Fix undefined children does not update children in state

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -131,7 +131,13 @@ export default function createConnect(React) {
         recomputeState(props = this.props) {
           const nextState = this.computeNextState(props);
           if (!shallowEqual(nextState, this.state)) {
-            this.setState(nextState);
+            this.setState({
+              ...Object.keys(this.state)
+                .reduce((r, k) => ({
+                  [k]: undefined
+                }), {}),
+              ...nextState,
+            });
           }
         }
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -180,6 +180,51 @@ describe('React', () => {
       expect(div.props.pass).toEqual('through');
     });
 
+    it('should remove undefined props', () => {
+      const store = createStore(() => ({}));
+      let props = {x: true};
+      let container;
+
+      @connect(()=>({}), ()=>({}))
+      class ConnectContainer extends Component {
+        render() {
+          return (
+              <div {...this.props} />
+          );
+        }
+      }
+
+      class HolderContainer extends Component {
+        render() {
+          return (
+            <ConnectContainer {...props} />
+          );
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          {() => (
+            <HolderContainer ref={instance => container = instance} />
+          )}
+        </Provider>
+      );
+
+      const propsBefore = {
+        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
+      };
+
+      props = {};
+      container.forceUpdate();
+
+      const propsAfter = {
+        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
+      };
+
+      expect(propsBefore.x).toEqual(true);
+      expect(propsAfter.x).toNotEqual(true);
+    });
+
     it('should ignore deep mutations in props', () => {
       const store = createStore(() => ({
         foo: 'bar'


### PR DESCRIPTION
If at first render you have children props, and at second not 
(this.props does not contain children element), 
this.state contains previous version of children.