### PR TITLE
Add failing test

### DIFF
--- a/src/components/createConnect.js
+++ b/src/components/createConnect.js
@@ -12,8 +12,6 @@ const defaultMergeProps = (stateProps, dispatchProps, parentProps) => ({
   ...dispatchProps
 });
 
-const resetValue = (_, key) => ({ [key]: undefined });
-
 function getDisplayName(Component) {
   return Component.displayName || Component.name || 'Component';
 }
@@ -82,7 +80,7 @@ export default function createConnect(React) {
         };
 
         shouldComponentUpdate(nextProps, nextState) {
-          return !shallowEqual(this.state, nextState);
+          return !shallowEqual(this.state.props, nextState.props);
         }
 
         constructor(props, context) {
@@ -99,7 +97,9 @@ export default function createConnect(React) {
 
           this.stateProps = computeStateProps(this.store);
           this.dispatchProps = computeDispatchProps(this.store);
-          this.state = this.computeNextState();
+          this.state = {
+            props: this.computeNextState()
+          };
         }
 
         recomputeStateProps() {
@@ -132,10 +132,9 @@ export default function createConnect(React) {
 
         recomputeState(props = this.props) {
           const nextState = this.computeNextState(props);
-          if (!shallowEqual(nextState, this.state)) {
+          if (!shallowEqual(nextState, this.state.props)) {
             this.setState({
-              ...Object.keys(this.state).reduce(resetValue, {}),
-              ...nextState
+              props: nextState
             });
           }
         }
@@ -185,7 +184,7 @@ export default function createConnect(React) {
         render() {
           return (
             <WrappedComponent ref='wrappedInstance'
-                              {...this.state} />
+                              {...this.state.props} />
           );
         }
       }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -222,6 +222,98 @@ describe('React', () => {
       };
 
       expect(propsBefore.x).toEqual(true);
+      expect('x' in propsAfter).toEqual(false, 'x prop must be removed');
+    });
+
+    it('should remove undefined props without mapDispatchToProps', () => {
+      const store = createStore(() => ({}));
+      let props = { x: true };
+      let container;
+
+      @connect(() => ({}))
+      class ConnectContainer extends Component {
+        render() {
+          return (
+              <div {...this.props} />
+          );
+        }
+      }
+
+      class HolderContainer extends Component {
+        render() {
+          return (
+            <ConnectContainer {...props} />
+          );
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          {() => (
+            <HolderContainer ref={instance => container = instance} />
+          )}
+        </Provider>
+      );
+
+      const propsBefore = {
+        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
+      };
+
+      props = {};
+      container.forceUpdate();
+
+      const propsAfter = {
+        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
+      };
+
+      expect(propsBefore.x).toEqual(true);
+      expect('x' in propsAfter).toEqual(false, 'x prop must be removed');
+    });
+
+    it('should remove undefined props without mapDispatchToProps', () => {
+      // in this failing test connect doesn't call render second time
+      // i can't understand why
+      const store = createStore(() => ({}));
+      let props = { x: true };
+      let container;
+
+      @connect(() => ({}))
+      class ConnectContainer extends Component {
+        render() {
+          return (
+              <div {...this.props} />
+          );
+        }
+      }
+
+      class HolderContainer extends Component {
+        render() {
+          return (
+            <ConnectContainer {...props} />
+          );
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          {() => (
+            <HolderContainer ref={instance => container = instance} />
+          )}
+        </Provider>
+      );
+
+      const propsBefore = {
+        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
+      };
+
+      props = {};
+      container.forceUpdate();
+
+      const propsAfter = {
+        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
+      };
+
+      expect(propsBefore.x).toEqual(true);
       expect(propsAfter.x).toNotEqual(true);
     });
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -270,53 +270,6 @@ describe('React', () => {
       expect('x' in propsAfter).toEqual(false, 'x prop must be removed');
     });
 
-    it('should remove undefined props without mapDispatchToProps', () => {
-      // in this failing test connect doesn't call render second time
-      // i can't understand why
-      const store = createStore(() => ({}));
-      let props = { x: true };
-      let container;
-
-      @connect(() => ({}))
-      class ConnectContainer extends Component {
-        render() {
-          return (
-              <div {...this.props} />
-          );
-        }
-      }
-
-      class HolderContainer extends Component {
-        render() {
-          return (
-            <ConnectContainer {...props} />
-          );
-        }
-      }
-
-      TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          {() => (
-            <HolderContainer ref={instance => container = instance} />
-          )}
-        </Provider>
-      );
-
-      const propsBefore = {
-        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
-      };
-
-      props = {};
-      container.forceUpdate();
-
-      const propsAfter = {
-        ...TestUtils.findRenderedDOMComponentWithTag(container, 'div').props
-      };
-
-      expect(propsBefore.x).toEqual(true);
-      expect(propsAfter.x).toNotEqual(true);
-    });
-
     it('should ignore deep mutations in props', () => {
       const store = createStore(() => ({
         foo: 'bar'


### PR DESCRIPTION
8.1 failing test
prehistory [here](https://github.com/gaearon/react-redux/pull/50#issuecomment-129953612)

Test in first commit is new.

Changes in second commit is about that such keys also need to be deleted from this.state