### PR TITLE
Enforce shape of store property

### DIFF
--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -10,7 +10,8 @@ export default function createProvider(React) {
     };
 
     static propTypes = {
-      children: PropTypes.func.isRequired
+      children: PropTypes.func.isRequired,
+      store: storeShape.isRequired
     };
 
     getChildContext() {


### PR DESCRIPTION
This produce better Error messages, when store property is not being provided.

In our case we migrated to redux-1.0.x and got the waring:
```
Warning: Failed Context Types: Required child context `store` was not specified in `Provider`
```
because previously the property holding the flux instance was named redux.

With the propTypes specified you would get the following warning: 
```
Warning: Failed propType: Required prop `store` was not specified in `Provider`
```
which makes it pretty clear how and where to fix the issue.